### PR TITLE
add the missing "}"

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -908,7 +908,7 @@ void MainWindow::on_pushButton_home_login_clicked()
     {
         ui->label_home_warning->show();
     }
-
+}
 
 // Helper Function Definitions
     // Reset all values in membership table widget


### PR DESCRIPTION
while resolving a merge conflict i probably deleted a "}" in mainwindow.cpp. just added it in so development can be fully functional again